### PR TITLE
Enable multi-architecture build and push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,13 @@ jobs:
           scan-ref: '.'
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -33,9 +36,10 @@ jobs:
           images: enver/label-nodes
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Hello,

We are using this tool to label AWS EKS nodes. We have recently deployed Graviton instances, as they are cheaper than Intel and AMD. We noticed that the image is not built for cross-platform/multi-architecture. Nothing in the Dockerfile looks like it should be incompatible with ARM, so it should be a simple change to the image build task.

Actions versions also bumped to latest. 